### PR TITLE
[WIP] Update to latest parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.642.2</version>
+    <version>3.53</version>
   </parent>
 
   <groupId>org.openshift.jenkins</groupId>
@@ -20,9 +20,8 @@
 
 
   <properties>
-    <maven.compiler.target>8</maven.compiler.target>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <java.level>8</java.level>
+    <jenkins.version>2.60.3</jenkins.version>
   </properties>
 
   <name>OpenShift Login Plugin</name>
@@ -80,13 +79,18 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>  <!-- forcing hamcrest-core:2.x to fix RequireUpperBoundDeps error-->
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.2</version>
+      <version>4.5.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -96,15 +100,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.2</version>
-      </plugin>
-    </plugins>
-  </build>
 
   <distributionManagement>
     <repository>


### PR DESCRIPTION
**KNOWN ISSUE: remaining FindBugs errors. Must either be fixed, or ignored temporarily.**

Will also bump minimum Jenkins version to 2.60.3 as anyway the minimum
java version was already 8.

Fixed related `RequireUpperBoundsDeps` errors:

```
INFO] Ignoring requireUpperBoundDeps in com.google.guava:guava
[WARNING] Rule 4: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.apache.httpcomponents:httpclient:4.5.2 paths to dependency are:
+-org.openshift.jenkins:openshift-login:1.0.22-SNAPSHOT
  +-org.apache.httpcomponents:httpclient:4.5.2
and
+-org.openshift.jenkins:openshift-login:1.0.22-SNAPSHOT
  +-com.google.oauth-client:google-oauth-client:1.30.2
    +-com.google.http-client:google-http-client:1.32.0
      +-org.apache.httpcomponents:httpclient:4.5.9
,
Require upper bound dependencies error for org.hamcrest:hamcrest-core:1.3 paths to dependency are:
+-org.openshift.jenkins:openshift-login:1.0.22-SNAPSHOT
  +-junit:junit:4.12
    +-org.hamcrest:hamcrest-core:1.3
and
+-org.openshift.jenkins:openshift-login:1.0.22-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-test-harness:2.56
    +-org.hamcrest:hamcrest-core:2.1
and
+-org.openshift.jenkins:openshift-login:1.0.22-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-test-harness:2.56
    +-org.hamcrest:hamcrest-library:2.1
      +-org.hamcrest:hamcrest-core:2.1
]
```